### PR TITLE
Add new GGUF models (1-bit/2-bit/3-bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 
 ## 新闻
 
+**[2024/03/27] 添加1-bit/2-bit/3-bit量化版GGUF模型：[[🤗HF]](https://huggingface.co/hfl)；同时，本项目已入驻机器之心SOTA!模型平台，欢迎关注：https://sota.jiqizhixin.com/project/chinese-mixtral**
+
 **[2024/03/26] 添加仿OpenAI API部署模式。详情查看：[📚v1.2版本发布日志](https://github.com/ymcui/Chinese-Mixtral/releases/tag/v1.2)**
 
 [2024/03/05] 开源模型训练和精调代码，发布技术报告。详情查看：[📚v1.1版本发布日志](https://github.com/ymcui/Chinese-Mixtral/releases/tag/v1.1)

--- a/README_EN.md
+++ b/README_EN.md
@@ -31,6 +31,8 @@ This project is developed based on the [Mixtral model](https://huggingface.co/mi
 
 ## News
 
+**[2024/03/27] Add 1-bit/2-bit/3-bit GGUF models: [[🤗HF]](https://huggingface.co/hfl); Meanwhile, this project has been added in the SOTA! model platform of Synced, welcome to follow: https://sota.jiqizhixin.com/project/chinese-mixtral**
+
 **[2024/03/26] Add deployment method of OpenAI-style API. See: [📚v1.2 Release Notes](https://github.com/ymcui/Chinese-Mixtral/releases/tag/v1.2)**
 
 [2024/03/05] Release pre-training and fine-tuning scripts. Technical reports are also available. See: [📚 v1.1 Release Notes](https://github.com/ymcui/Chinese-Mixtral/releases/tag/v1.1)


### PR DESCRIPTION
### Description

This PR adds new lower-bit quantized GGUF models for Chinese-Mixtral-Instruct.

- 1-bit: IQ1_S, IQ1_M
- 2-bit: IQ2_M, IQ2_S, IQ2_XS, IQ2_XXS
- 3-bit: IQ3_M, IQ3_S, IQ3_XS, IQ3_XXS
- 4-bit: IQ4_XS, IQ4_NL

Download these models from: https://huggingface.co/hfl/chinese-mixtral-instruct-gguf/tree/main

#### Performance

| Quant   | Size ↓  | PPL                |
| ------- | ------- | ------------------ |
| IQ1_S   | 9.8 GB  | 9.5782 +/- 0.08909 |
| IQ1_M   | 10.8 GB | 7.4666 +/- 0.06741 |
| IQ2_XXS | 12.3 GB | 6.3923 +/- 0.05674 |
| IQ2_XS  | 13.7 GB | 6.0606 +/- 0.05834 |
| IQ2_S   | 14.1 GB | 4.7617 +/- 0.04177 |
| IQ2_M   | 15.5 GB | 4.5911 +/- 0.04054 |
| Q2_K    | 17.3 GB | 4.8592 +/- 0.04303 |
| IQ3_XXS | 18.3 GB | 4.3557 +/- 0.03846 |
| IQ3_XS  | 19.3 GB | 4.3328 +/- 0.03779 |
| IQ3_S   | 20.4 GB | 4.3138 +/- 0.03785 |
| IQ3_M   | 21.4 GB | 4.3024 +/- 0.03775 |
| Q3_K    | 22.5 GB | 4.4334 +/- 0.03937 |
| IQ4_XS  | 25.1 GB | 4.2324 +/- 0.03757 |
| Q4_0    | 26.4 GB | 4.2688 +/- 0.03787 |
| IQ4_NL  | 26.5 GB | 4.2384 +/- 0.03763 |
| Q4_K    | 28.4 GB | 4.2433 +/- 0.03768 |
| Q5_0    | 32.2 GB | 4.2142 +/- 0.03733 |
| Q5_K    | 33.2 GB | 4.2177 +/- 0.03743 |
| Q6_K    | 38.4 GB | 4.2184 +/- 0.03754 |
| Q8_0    | 49.6 GB | 4.2053 +/- 0.03732 |
| F16     | 93.5 GB | x                  |

### Related Issue

None